### PR TITLE
Adding interfaces to implement callbacks in case of a failed sync

### DIFF
--- a/app/src/main/java/com/odoo/core/orm/OModel.java
+++ b/app/src/main/java/com/odoo/core/orm/OModel.java
@@ -1192,6 +1192,11 @@ public class OModel implements ISyncServiceListener {
         // Will be over ride by extending model
     }
 
+    @Override
+    public void onSyncFailed() {
+        // Will be over ride by extending model
+    }
+
     public SyncUtils sync() {
         return SyncUtils.get(mContext);
     }

--- a/app/src/main/java/com/odoo/core/orm/OModel.java
+++ b/app/src/main/java/com/odoo/core/orm/OModel.java
@@ -1197,6 +1197,11 @@ public class OModel implements ISyncServiceListener {
         // Will be over ride by extending model
     }
 
+    @Override
+    public void onSyncTimedOut() {
+        // Will be over ride by extending model
+    }
+
     public SyncUtils sync() {
         return SyncUtils.get(mContext);
     }

--- a/app/src/main/java/com/odoo/core/service/ISyncServiceListener.java
+++ b/app/src/main/java/com/odoo/core/service/ISyncServiceListener.java
@@ -25,4 +25,7 @@ public interface ISyncServiceListener {
     public void onSyncFinished();
 
     public void onSyncFailed();
+
+    public void onSyncTimedOut();
+
 }

--- a/app/src/main/java/com/odoo/core/service/ISyncServiceListener.java
+++ b/app/src/main/java/com/odoo/core/service/ISyncServiceListener.java
@@ -23,4 +23,6 @@ public interface ISyncServiceListener {
     public void onSyncStarted();
 
     public void onSyncFinished();
+
+    public void onSyncFailed();
 }

--- a/app/src/main/java/com/odoo/core/service/OSyncAdapter.java
+++ b/app/src/main/java/com/odoo/core/service/OSyncAdapter.java
@@ -228,6 +228,7 @@ public class OSyncAdapter extends AbstractThreadedSyncAdapter {
             model.onSyncFinished();
         } catch (Exception e) {
             e.printStackTrace();
+            model.onSyncFailed();
         }
         // Performing next sync if any in service
         if (mSyncFinishListeners.containsKey(model.getModelName())) {

--- a/app/src/main/java/com/odoo/core/service/OSyncAdapter.java
+++ b/app/src/main/java/com/odoo/core/service/OSyncAdapter.java
@@ -182,6 +182,7 @@ public class OSyncAdapter extends AbstractThreadedSyncAdapter {
             if (response == null) {
                 // FIXME: Check in library. May be timeout issue with slow network.
                 Log.w(TAG, "Response null from server.");
+                model.onSyncTimedOut();
                 return;
             }
             if (response.containsKey("error")) {


### PR DESCRIPTION
Following up issue #201, where I complained about the lack of callbacks for failed syncs, I implemented two brand new interfaces in ISyncServiceListener:
-  onSyncFailed is called when a sync fails for any reasons;
-  onSyncTimedOut is more specific and is called when the request times out (server down, no internet connection, etc.).

They work pretty great in my tests, so I'm opening this PR hoping it will be of help to others too. 