### PR TITLE
[FIX] OSyncAdapter: relationrecords sync issue

### DIFF
--- a/app/src/main/java/com/odoo/core/service/OSyncAdapter.java
+++ b/app/src/main/java/com/odoo/core/service/OSyncAdapter.java
@@ -261,7 +261,7 @@ public class OSyncAdapter extends AbstractThreadedSyncAdapter {
             if (!record.getUniqueIds().isEmpty()) {
                 ODomain domain = new ODomain();
                 domain.add("id", "in", record.getUniqueIds());
-                syncData(rel_model, user, domain, result, true, false);
+                syncData(rel_model, user, domain, result, false, false);
             }
             // Updating manyToOne record with their relation record row_id
             switch (record.getRelationType()) {


### PR DESCRIPTION
This patch fixes an issue when synchronizing relations of a model.
Before, the handleRelationRecords method called the syncData method
with the checkForDataLimit boolean to true.

This patch sets this same boolean to false.

Indeed, it used to create a request with in the same domain "id in"
and "id not in".
Then, the objects retrieved from the server are not complete but
partially retrieved.

By setting the boolean to false, the issue with the domain is not
present anymore and the objects are now complete.

Finally, this boolean was at false before this commit:
https://github.com/Odoo-mobile/framework/commit/2f54926a4849e06f79d8d2019c5f6de94489b6fe
It then becomes true.

The related issue is #218
