### PR TITLE
[FIX] framework: fix timeout requestSync / auth

### DIFF
--- a/app/src/main/java/com/odoo/core/rpc/wrapper/OdooWrapper.java
+++ b/app/src/main/java/com/odoo/core/rpc/wrapper/OdooWrapper.java
@@ -200,10 +200,11 @@ public class OdooWrapper<T> implements Response.Listener<JSONObject> {
             requestQueue.add(request);
         } else {
             JsonObjectRequest request = new JsonObjectRequest(url, postData, requestFuture, requestFuture);
+            request.setRetryPolicy(new DefaultRetryPolicy(new_request_timeout, new_request_max_retry,
+                    DefaultRetryPolicy.DEFAULT_BACKOFF_MULT));
             requestQueue.add(request);
             try {
-                OdooResponse response = parseToResponse(requestFuture.get(new_request_timeout,
-                        TimeUnit.MILLISECONDS));
+                OdooResponse response = parseToResponse(requestFuture.get());
                 backResponse.setResponse(response);
             } catch (Exception e) {
                 OdooLog.e(e);

--- a/app/src/main/java/com/odoo/core/service/OSyncAdapter.java
+++ b/app/src/main/java/com/odoo/core/service/OSyncAdapter.java
@@ -296,6 +296,7 @@ public class OSyncAdapter extends AbstractThreadedSyncAdapter {
             if (odoo == null) {
                 odoo = Odoo.createQuickInstance(context, user.getHost());
                 OUser mUser = odoo
+                        .withRetryPolicy(OConstants.RPC_REQUEST_TIME_OUT, OConstants.RPC_REQUEST_RETRIES)
                         .authenticate(user.getUsername(), user.getPassword(), user.getDatabase());
                 app.setOdoo(odoo, user);
                 if (mUser != null) {


### PR DESCRIPTION
This patch fixes the timeout when performing a synchronization. It now
properly uses the new variables.