### PR TITLE
[FIX] sync_data_limit issue

### DIFF
--- a/app/src/main/java/com/odoo/addons/customers/Customers.java
+++ b/app/src/main/java/com/odoo/addons/customers/Customers.java
@@ -220,7 +220,7 @@ public class Customers extends BaseFragment implements ISyncStatusObserverListen
     @Override
     public void onRefresh() {
         if (inNetwork()) {
-            parent().sync(new OnSyncFinishListener() {
+            parent().sync(KEY, new OnSyncFinishListener() {
                 @Override
                 public void onSyncFinish() {
                     Log.d(KEY, "onSyncFinish() called");

--- a/app/src/main/java/com/odoo/addons/customers/Customers.java
+++ b/app/src/main/java/com/odoo/addons/customers/Customers.java
@@ -28,6 +28,7 @@ import android.support.v4.app.LoaderManager;
 import android.support.v4.content.CursorLoader;
 import android.support.v4.content.Loader;
 import android.support.v4.widget.SwipeRefreshLayout;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -41,6 +42,7 @@ import android.widget.Toast;
 import com.odoo.R;
 import com.odoo.base.addons.res.ResPartner;
 import com.odoo.core.orm.ODataRow;
+import com.odoo.core.service.OnSyncFinishListener;
 import com.odoo.core.support.addons.fragment.BaseFragment;
 import com.odoo.core.support.addons.fragment.IOnSearchViewChangeListener;
 import com.odoo.core.support.addons.fragment.ISyncStatusObserverListener;
@@ -218,7 +220,14 @@ public class Customers extends BaseFragment implements ISyncStatusObserverListen
     @Override
     public void onRefresh() {
         if (inNetwork()) {
-            parent().sync().requestSync(ResPartner.AUTHORITY);
+            parent().sync(new OnSyncFinishListener() {
+                @Override
+                public void onSyncFinish() {
+                    Log.d(KEY, "onSyncFinish() called");
+                    Toast.makeText(getActivity(), _s(R.string.toast_sync_complete), Toast.LENGTH_LONG)
+                            .show();
+                }
+            }).requestSync(ResPartner.AUTHORITY);
             setSwipeRefreshing(true);
         } else {
             hideRefreshingProgress();

--- a/app/src/main/java/com/odoo/addons/customers/Customers.java
+++ b/app/src/main/java/com/odoo/addons/customers/Customers.java
@@ -152,6 +152,7 @@ public class Customers extends BaseFragment implements ISyncStatusObserverListen
                     OControls.setGone(mView, R.id.loadingProgress);
                     OControls.setVisible(mView, R.id.swipe_container);
                     OControls.setGone(mView, R.id.data_list_no_item);
+                    OControls.setGone(mView, R.id.noItemsView);
                     setHasSwipeRefreshView(mView, R.id.swipe_container, Customers.this);
                 }
             }, 500);
@@ -161,6 +162,7 @@ public class Customers extends BaseFragment implements ISyncStatusObserverListen
                 public void run() {
                     OControls.setGone(mView, R.id.loadingProgress);
                     OControls.setGone(mView, R.id.swipe_container);
+                    OControls.setVisible(mView, R.id.noItemsView);
                     OControls.setVisible(mView, R.id.data_list_no_item);
                     setHasSwipeRefreshView(mView, R.id.data_list_no_item, Customers.this);
                     OControls.setImage(mView, R.id.icon, R.drawable.ic_action_customers);
@@ -224,6 +226,26 @@ public class Customers extends BaseFragment implements ISyncStatusObserverListen
                 @Override
                 public void onSyncFinish() {
                     Log.d(KEY, "onSyncFinish() called");
+                    final SwipeRefreshLayout dataListNoItem = (SwipeRefreshLayout)
+                            getActivity().findViewById(R.id.data_list_no_item);
+                    if (dataListNoItem.isRefreshing()) {
+                        dataListNoItem.post(new Runnable() {
+                            @Override
+                            public void run() {
+                                dataListNoItem.setRefreshing(false);
+                            }
+                        });
+                    }
+                    final SwipeRefreshLayout swipeContainer = (SwipeRefreshLayout)
+                            getActivity().findViewById(R.id.swipe_container);
+                    if (swipeContainer.isRefreshing()) {
+                        swipeContainer.post(new Runnable() {
+                            @Override
+                            public void run() {
+                                swipeContainer.setRefreshing(false);
+                            }
+                        });
+                    }
                     Toast.makeText(getActivity(), _s(R.string.toast_sync_complete), Toast.LENGTH_LONG)
                             .show();
                 }

--- a/app/src/main/java/com/odoo/core/service/OnSyncFinishListener.java
+++ b/app/src/main/java/com/odoo/core/service/OnSyncFinishListener.java
@@ -1,0 +1,9 @@
+package com.odoo.core.service;
+
+/**
+ * This interface use for adding listener on model sync finish.
+ */
+
+public interface OnSyncFinishListener {
+    void onSyncFinish();
+}

--- a/app/src/main/java/com/odoo/core/utils/OPreferenceManager.java
+++ b/app/src/main/java/com/odoo/core/utils/OPreferenceManager.java
@@ -68,13 +68,15 @@ public class OPreferenceManager {
     }
 
     public int getInt(String key, int default_value) {
-        try {
-            String value = mPref.getString(key, String.valueOf(default_value));
-            return Integer.parseInt(value);
-        } catch (Exception e) {
-            Log.e(TAG, "getInt: ", e);
+        if (mPref.getAll().get(key) instanceof String) {
+            try {
+                return Integer.parseInt(mPref.getString(key, default_value + ""));
+            } catch (NumberFormatException e) {
+                Log.d(TAG, e.getMessage());
+                return -1;
+            }
         }
-        return default_value;
+        return mPref.getInt(key, default_value);
     }
 
     public void setBoolean(String key, Boolean value) {

--- a/app/src/main/java/com/odoo/core/utils/OPreferenceManager.java
+++ b/app/src/main/java/com/odoo/core/utils/OPreferenceManager.java
@@ -21,6 +21,7 @@ package com.odoo.core.utils;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -68,10 +69,12 @@ public class OPreferenceManager {
 
     public int getInt(String key, int default_value) {
         try {
-            return Integer.parseInt(mPref.getString(key, default_value + ""));
+            String value = mPref.getString(key, String.valueOf(default_value));
+            return Integer.parseInt(value);
         } catch (Exception e) {
-            return mPref.getInt(key, default_value);
+            Log.e(TAG, "getInt: ", e);
         }
+        return default_value;
     }
 
     public void setBoolean(String key, Boolean value) {

--- a/app/src/main/res/layout/common_listview.xml
+++ b/app/src/main/res/layout/common_listview.xml
@@ -16,7 +16,9 @@
             android:layout_height="wrap_content"
             android:visibility="gone">
 
-            <include layout="@layout/base_no_items_view" />
+            <include
+                android:id="@+id/noItemsView"
+                layout="@layout/base_no_items_view" />
         </android.support.v4.widget.SwipeRefreshLayout>
 
         <android.support.v4.widget.SwipeRefreshLayout

--- a/app/src/main/res/values/base-strings.xml
+++ b/app/src/main/res/values/base-strings.xml
@@ -71,6 +71,7 @@
     <string name="toast_are_you_sure_logout">Are you sure want to logout ?</string>
     <string name="toast_are_you_sure_delete_account">Are you sure want to delete account ?</string>
     <string name="toast_network_required">Network required</string>
+    <string name="toast_sync_complete">Sync complete</string>
     <string name="toast_account_removed">Account Removed Successfully</string>
     <string name="toast_no_activity_found_to_handle_file">No activity found to handle file</string>
     <string name="toast_updating_password">Updating password</string>


### PR DESCRIPTION
Solved Sync Data Limit issue. remove ` return mPref.getInt(key, default_value);` from `catch` block. Added Exception message in LogCat. it was `ClassCastException` which was not showing.