### PR TITLE
[FIX] db: create one database per user

### DIFF
--- a/app/src/main/java/com/odoo/core/orm/OModel.java
+++ b/app/src/main/java/com/odoo/core/orm/OModel.java
@@ -115,7 +115,7 @@ public class OModel implements ISyncServiceListener {
         this.model_name = model_name;
         if (mUser != null) {
             mOdooVersion = mUser.getOdooVersion();
-            if (sqLite == null) {
+            if (sqLite == null || !sqLite.getUserAndroidName().equals(mUser.getAndroidName())) {
                 sqLite = new OSQLite(mContext, mUser);
             }
         }

--- a/app/src/main/java/com/odoo/core/orm/OSQLite.java
+++ b/app/src/main/java/com/odoo/core/orm/OSQLite.java
@@ -160,4 +160,7 @@ public class OSQLite extends SQLiteOpenHelper {
                 "/data/" + app.getPackageName() + "/databases/" + getDatabaseName();
     }
 
+    public String getUserAndroidName() {
+        return (this.mUser != null) ? this.mUser.getAndroidName() : "";
+    }
 }


### PR DESCRIPTION
It appears that several users can share the same local database, which
is not the announced behaviour.
This patch tries to solve it by improving the test that creates a new
database or not.
An issue has also been opened on the Odoo Mobile Framework Github
project.
https://github.com/Odoo-mobile/framework/issues/210