### PR TITLE
[FIX] sync_data_limit issue

### DIFF
--- a/app/src/main/java/com/odoo/core/utils/OPreferenceManager.java
+++ b/app/src/main/java/com/odoo/core/utils/OPreferenceManager.java
@@ -73,7 +73,7 @@ public class OPreferenceManager {
                 return Integer.parseInt(mPref.getString(key, default_value + ""));
             } catch (NumberFormatException e) {
                 Log.d(TAG, e.getMessage());
-                return -1;
+                return default_value;
             }
         }
         return mPref.getInt(key, default_value);

--- a/app/src/main/java/com/odoo/core/utils/OPreferenceManager.java
+++ b/app/src/main/java/com/odoo/core/utils/OPreferenceManager.java
@@ -21,6 +21,7 @@ package com.odoo.core.utils;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -67,11 +68,15 @@ public class OPreferenceManager {
     }
 
     public int getInt(String key, int default_value) {
-        try {
-            return Integer.parseInt(mPref.getString(key, default_value + ""));
-        } catch (Exception e) {
-            return mPref.getInt(key, default_value);
+        if (mPref.getAll().get(key) instanceof String) {
+            try {
+                return Integer.parseInt(mPref.getString(key, default_value + ""));
+            } catch (NumberFormatException e) {
+                Log.d(TAG, e.getMessage());
+                return -1;
+            }
         }
+        return mPref.getInt(key, default_value);
     }
 
     public void setBoolean(String key, Boolean value) {


### PR DESCRIPTION
Solved `sync_data_limit` issue.

Open the Setting Screen
Click on  Sync Data Limit option
Select any option.

now, inside OSyncAdapter at line No. 165 `int data_limit = preferenceManager.getInt("sync_data_limit", 60);` will always gives you 60. with no matter which value you've set from settings. because of internal `ClassCastException`.