### PR TITLE
[FIX] noItemsView fix

### DIFF
--- a/app/src/main/java/com/odoo/addons/customers/Customers.java
+++ b/app/src/main/java/com/odoo/addons/customers/Customers.java
@@ -143,6 +143,26 @@ public class Customers extends BaseFragment implements ISyncStatusObserverListen
     @Override
     public void onLoadFinished(Loader<Cursor> loader, Cursor data) {
         mAdapter.changeCursor(data);
+        final SwipeRefreshLayout dataListNoItem = (SwipeRefreshLayout)
+                getActivity().findViewById(R.id.data_list_no_item);
+        if (dataListNoItem.isRefreshing()) {
+            dataListNoItem.post(new Runnable() {
+                @Override
+                public void run() {
+                    dataListNoItem.setRefreshing(false);
+                }
+            });
+        }
+        final SwipeRefreshLayout swipeContainer = (SwipeRefreshLayout)
+                getActivity().findViewById(R.id.swipe_container);
+        if (swipeContainer.isRefreshing()) {
+            swipeContainer.post(new Runnable() {
+                @Override
+                public void run() {
+                    swipeContainer.setRefreshing(false);
+                }
+            });
+        }
         if (data.getCount() > 0) {
             new Handler().postDelayed(new Runnable() {
                 @Override
@@ -150,6 +170,7 @@ public class Customers extends BaseFragment implements ISyncStatusObserverListen
                     OControls.setGone(mView, R.id.loadingProgress);
                     OControls.setVisible(mView, R.id.swipe_container);
                     OControls.setGone(mView, R.id.data_list_no_item);
+                    OControls.setGone(mView, R.id.noItemsView);
                     setHasSwipeRefreshView(mView, R.id.swipe_container, Customers.this);
                 }
             }, 500);
@@ -159,6 +180,7 @@ public class Customers extends BaseFragment implements ISyncStatusObserverListen
                 public void run() {
                     OControls.setGone(mView, R.id.loadingProgress);
                     OControls.setGone(mView, R.id.swipe_container);
+                    OControls.setVisible(mView, R.id.noItemsView);
                     OControls.setVisible(mView, R.id.data_list_no_item);
                     setHasSwipeRefreshView(mView, R.id.data_list_no_item, Customers.this);
                     OControls.setImage(mView, R.id.icon, R.drawable.ic_action_customers);

--- a/app/src/main/res/layout/common_listview.xml
+++ b/app/src/main/res/layout/common_listview.xml
@@ -16,7 +16,9 @@
             android:layout_height="wrap_content"
             android:visibility="gone">
 
-            <include layout="@layout/base_no_items_view" />
+            <include
+                android:id="@+id/noItemsView"
+                layout="@layout/base_no_items_view" />
         </android.support.v4.widget.SwipeRefreshLayout>
 
         <android.support.v4.widget.SwipeRefreshLayout


### PR DESCRIPTION
`no_item_view` still show when sync finish completely, records fetched from server & got display in `ListView`.
You can reproduce it by following:
- Fresh install the framework app.
- on First time when `OdooActivity` get open, perform `pull to refresh` operation.<br /><br />

![screenshot_20161116-033520](https://cloud.githubusercontent.com/assets/7657803/20326863/99bda708-abb0-11e6-92f2-6d7d865c44fc.png)
