### PR TITLE
[IMP] Use numeric keyboards for OInteger and OFloat types in a OField

### DIFF
--- a/app/src/main/java/odoo/controls/OEditTextField.java
+++ b/app/src/main/java/odoo/controls/OEditTextField.java
@@ -26,6 +26,7 @@ import android.os.Build;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.view.View;
+import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -48,6 +49,7 @@ public class OEditTextField extends LinearLayout implements IOControlData,
     private float textSize = -1;
     private int appearance = -1;
     private int textColor = Color.BLACK;
+    private int inputtype = -1;
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public OEditTextField(Context context, AttributeSet attrs,
@@ -101,6 +103,9 @@ public class OEditTextField extends LinearLayout implements IOControlData,
             }
             if (appearance > -1) {
                 edtText.setTextAppearance(mContext, appearance);
+            }
+            if (inputtype > -1) {
+                edtText.setInputType(inputtype);
             }
             edtText.setTextColor(textColor);
             addView(edtText);
@@ -183,6 +188,14 @@ public class OEditTextField extends LinearLayout implements IOControlData,
     @Override
     public Boolean isEditable() {
         return mEditable;
+    }
+
+    public void setInputType(int type) {
+        inputtype = type;
+    }
+
+    public int getInputType() {
+        return inputtype;
     }
 
     public void setHint(String hint) {

--- a/app/src/main/java/odoo/controls/OField.java
+++ b/app/src/main/java/odoo/controls/OField.java
@@ -30,6 +30,7 @@ import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.EditorInfo;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -111,7 +112,7 @@ public class OField extends LinearLayout implements IOControlData.ValueUpdateLis
     }
 
     public enum FieldType {
-        Text, Boolean, ManyToOne, Chips, Selection, Date, Time, DateTime, Blob, RelationType;
+        Text, Boolean, ManyToOne, Chips, Selection, Date, Time, DateTime, Blob, RelationType, Integer, Float;
 
         public static FieldType getTypeValue(int type_val) {
             switch (type_val) {
@@ -133,6 +134,10 @@ public class OField extends LinearLayout implements IOControlData.ValueUpdateLis
                     return FieldType.Blob;
                 case 8:
                     return FieldType.Time;
+                case 9:
+                    return FieldType.Integer;
+                case 10:
+                    return FieldType.Float;
             }
             return FieldType.Text;
         }
@@ -267,6 +272,12 @@ public class OField extends LinearLayout implements IOControlData.ValueUpdateLis
             case Blob:
                 controlView = initBlobControl();
                 break;
+            case Integer:
+                controlView = initIntegerControl();
+                break;
+            case Float:
+                controlView = initFloatControl();
+                break;
             default:
                 return;
         }
@@ -313,13 +324,20 @@ public class OField extends LinearLayout implements IOControlData.ValueUpdateLis
         try {
             // Varchar
             if (type_class.isAssignableFrom(OVarchar.class)
-                    || type_class.isAssignableFrom(OInteger.class)
-                    || type_class.isAssignableFrom(OFloat.class)) {
+                    || type_class.isAssignableFrom(OText.class)) {
                 return FieldType.Text;
             }
             // boolean
             if (type_class.isAssignableFrom(OBoolean.class)) {
                 return FieldType.Boolean;
+            }
+            // Integer
+            if (type_class.isAssignableFrom(OInteger.class)) {
+                return FieldType.Integer;
+            }
+            // Float
+            if (type_class.isAssignableFrom(OFloat.class)) {
+                return FieldType.Float;
             }
 
             // Blob
@@ -334,10 +352,6 @@ public class OField extends LinearLayout implements IOControlData.ValueUpdateLis
             // Date
             if (type_class.isAssignableFrom(ODate.class)) {
                 return FieldType.Date;
-            }
-            // Text
-            if (type_class.isAssignableFrom(OText.class)) {
-                return FieldType.Text;
             }
             // FIXME: WebView type
             if (type_class.isAssignableFrom(OHtml.class)) {
@@ -459,6 +473,21 @@ public class OField extends LinearLayout implements IOControlData.ValueUpdateLis
         blob.setColumn(mColumn);
         blob.setWidgetType(mWidgetType);
         return blob;
+    }
+
+    // EditText control (TextView, EditText)
+    private View initIntegerControl() {
+        OEditTextField edt = (OEditTextField) initTextControl();
+        edt.setInputType(EditorInfo.TYPE_CLASS_NUMBER | EditorInfo.TYPE_NUMBER_VARIATION_PASSWORD
+                | EditorInfo.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD);
+        return edt;
+    }
+
+    // EditText control (TextView, EditText)
+    private View initFloatControl() {
+        OEditTextField edt = (OEditTextField) initTextControl();
+        edt.setInputType(EditorInfo.TYPE_CLASS_NUMBER | EditorInfo.TYPE_NUMBER_FLAG_DECIMAL);
+        return edt;
     }
 
     private TextView getLabelView() {

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -28,6 +28,8 @@
             <enum name="DateTime" value="6" />
             <enum name="Blob" value="7" />
             <enum name="Time" value="8" />
+            <enum name="Integer" value="9" />
+            <enum name="Float" value="10" />
         </attr>
         <attr name="widgetType">
             <enum name="Switch" value="0" />


### PR DESCRIPTION
Recent state: The OInteger and OFloat types in a OField have been mapped to a
OEditTextField that always used a normal text keyboard. Thus, it was possible
to enter non-numeric characters that cannot be stored in the database, so that
is was necessary to do input checks etc.

Now, new FieldTypes 'Integer' and 'Float' are introduced. In a OField, the
keyboard for a OInteger type is restricted to only digits, and the keyboard for
a OFloat type is restricted to digits and a (single) dot for fractional digits.