### PR TITLE
[IMP] Add getter for floats and avoid NullPointerExceptions in OValues

### DIFF
--- a/app/src/main/java/com/odoo/core/orm/OValues.java
+++ b/app/src/main/java/com/odoo/core/orm/OValues.java
@@ -58,26 +58,39 @@ public class OValues implements Serializable {
         return _values.get(key);
     }
 
-    public long getLong(String key) {
-        if (_values.get(key).toString().equals("false")) {
-            return -1;
+    public Long getLong(String key) {
+        if (!contains(key) || get(key).toString().equals("false")) {
+            return -1L;
         }
-        return Long.parseLong(_values.get(key).toString());
+        return Long.parseLong(get(key).toString());
     }
 
     public Integer getInt(String key) {
-        if (_values.get(key).toString().equals("false")) {
+        if (!contains(key) || get(key).toString().equals("false")) {
             return -1;
         }
-        return Integer.parseInt(_values.get(key).toString());
+        return Integer.parseInt(get(key).toString());
+    }
+
+    public Float getFloat(String key) {
+        if (!contains(key) || get(key).toString().equals("false")) {
+            return -1f;
+        }
+        return Float.parseFloat(get(key).toString());
     }
 
     public String getString(String key) {
-        return _values.get(key).toString();
+        if (!contains(key)) {
+            return "";
+        }
+        return get(key).toString();
     }
 
     public Boolean getBoolean(String key) {
-        return Boolean.parseBoolean(_values.get(key).toString());
+        if (!contains(key)) {
+            return false;
+        }
+        return Boolean.parseBoolean(get(key).toString());
     }
 
     public boolean contains(String key) {


### PR DESCRIPTION
As OValues are closely related to ODataRecords which are using float values,
there should also be a getter for float values for OValues.

As all getters in OValues were using the wrapper classes for the primitive data
types, this commit also changes the return type for long values to 'Long'.

Until now, a NullPointerException has been thrown if someone tried to use the
typed getters in OValues for non-existant keys. This has been changed as well.
Instead, the methods are returning the same value as if the value of the field
would have been 'false'.